### PR TITLE
Corrected Rating.ConservativeRating

### DIFF
--- a/Skills/Rating.cs
+++ b/Skills/Rating.cs
@@ -57,7 +57,7 @@ namespace Moserware.Skills
         /// </summary>
         public double ConservativeRating
         {
-            get { return _Mean - ConservativeStandardDeviationMultiplier*_StandardDeviation; }
+            get { return _Mean - _ConservativeStandardDeviationMultiplier*_StandardDeviation; }
         }
 
         public static Rating GetPartialUpdate(Rating prior, Rating fullPosterior, double updatePercentage)


### PR DESCRIPTION
It was always using the default stddev multipler of 3.0.
